### PR TITLE
Support optional precision for PostgreSQL time and timestamp data types

### DIFF
--- a/src/main/java/de/erdesignerng/dialect/postgres/PostgresDataType.java
+++ b/src/main/java/de/erdesignerng/dialect/postgres/PostgresDataType.java
@@ -56,10 +56,14 @@ public class PostgresDataType extends GenericDataTypeImpl {
 			theReturn = theBaseName;
 		} else {
 			String theAppend = patternToType(aAttribute);
+			int p = theBaseName.indexOf("(");
 			if (theAppend.length() == 0) {
-				theReturn = theBaseName;
+				if (p > 0 && theBaseName.charAt(p + 1) == ')') { // remove empty ()
+					theReturn = new StringBuilder(theBaseName).delete(p, p + 2).toString();
+				} else {
+					theReturn = theBaseName;
+				}
 			} else {
-				int p = theBaseName.indexOf("(");
 				if (p > 0) {
 					theReturn = new StringBuilder(theBaseName).insert(p + 1, theAppend).toString();
 				} else {

--- a/src/main/java/de/erdesignerng/dialect/postgres/PostgresDialect.java
+++ b/src/main/java/de/erdesignerng/dialect/postgres/PostgresDialect.java
@@ -91,10 +91,10 @@ public final class PostgresDialect extends Dialect {
 		registerType(createDataType("smallserial", "", true, Types.SMALLINT));
 		registerType(createDataType("serial", "", true, Types.INTEGER));
 		registerType(createDataType("text", "", Types.VARCHAR));
-		registerType(createDataType("time", "", Types.TIME));
-		registerType(createDataType("time with time zone", "", Types.TIME));
-		registerType(createDataType("timestamp", "", Types.TIMESTAMP));
-		registerType(createDataType("timestamp with time zone", "", Types.TIMESTAMP));
+		registerType(createDataType("time", "[" + GenericDataTypeImpl.SIZE_TOKEN + "]", Types.TIME));
+		registerType(createDataType("time() with time zone", "[" + GenericDataTypeImpl.SIZE_TOKEN + "]", Types.TIME));
+		registerType(createDataType("timestamp", "[" + GenericDataTypeImpl.SIZE_TOKEN + "]", Types.TIMESTAMP));
+		registerType(createDataType("timestamp() with time zone", "[" + GenericDataTypeImpl.SIZE_TOKEN + "]", Types.TIMESTAMP));
 		registerType(createDataType("tsquery", "", Types.OTHER));
 		registerType(createDataType("tsvector", "", Types.OTHER));
 		registerType(createDataType("txid_snapshot", "", Types.OTHER));


### PR DESCRIPTION
Fixes issue #136 as follows:

- Changes in the src/main/java/de/erdesignerng/dialect/postgres/PostgresDialect.java file allow four data types to accept a size token:
  - time
  - time with time zone
  - timestamp
  - timestamp with time zone
- Changes in the src/main/java/de/erdesignerng/dialect/postgres/PostgresDataType.java file remove the extra pair of parenthesis (which is only required for the size parameter) whenever the size parameter is not configured